### PR TITLE
Fixed bug where "endash" character was not parsed correctly by utf-8 encoding.

### DIFF
--- a/src/pyaltiumlib/datatypes/parametercollection.py
+++ b/src/pyaltiumlib/datatypes/parametercollection.py
@@ -241,7 +241,7 @@ class SchematicPin(ParameterCollection):
         
         entry_length = data.read_int8()   
         data.read_int8() # Why?
-        record["Description"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252") 
+        record["Description"] = "" if entry_length == 0 else data.read(entry_length).decode("windows-1252") 
         
         record["Electrical_Type"] = data.read_int8() 
         
@@ -261,10 +261,10 @@ class SchematicPin(ParameterCollection):
         record["Color"] = data.read_int32()
 
         entry_length = data.read_int8() 
-        record["Name"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252") 
+        record["Name"] = "" if entry_length == 0 else data.read(entry_length).decode("windows-1252") 
 
         entry_length = data.read_int8() 
-        record["Designator"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252")
+        record["Designator"] = "" if entry_length == 0 else data.read(entry_length).decode("windows-1252")
                                 
         self.num_blocks = 1
         self.collection.append(record) 

--- a/src/pyaltiumlib/datatypes/parametercollection.py
+++ b/src/pyaltiumlib/datatypes/parametercollection.py
@@ -241,7 +241,7 @@ class SchematicPin(ParameterCollection):
         
         entry_length = data.read_int8()   
         data.read_int8() # Why?
-        record["Description"] = "" if entry_length == 0 else data.read(entry_length).decode("utf-8") 
+        record["Description"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252") 
         
         record["Electrical_Type"] = data.read_int8() 
         
@@ -261,10 +261,10 @@ class SchematicPin(ParameterCollection):
         record["Color"] = data.read_int32()
 
         entry_length = data.read_int8() 
-        record["Name"] = "" if entry_length == 0 else data.read(entry_length).decode("utf-8") 
+        record["Name"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252") 
 
         entry_length = data.read_int8() 
-        record["Designator"] = "" if entry_length == 0 else data.read(entry_length).decode("utf-8")
+        record["Designator"] = "" if entry_length == 0 else data.read(entry_length)decode("windows-1252")
                                 
         self.num_blocks = 1
         self.collection.append(record) 


### PR DESCRIPTION
I had an endash in my opamp symbol as the minus and the library kept spewing decoding errors and wouldn't parse the symbol properly. It works by changing the decoding style.